### PR TITLE
Support Dark Mode in About dialog

### DIFF
--- a/App/Resources/English.lproj/Credits.rtf
+++ b/App/Resources/English.lproj/Credits.rtf
@@ -1,23 +1,26 @@
 {\rtf1\ansi\ansicpg1252\cocoartf2511
 \cocoatextscaling0\cocoaplatform0{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
-{\*\expandedcolortbl;;}
-\paperw11900\paperh16840\margl1440\margr1440\vieww19460\viewh15440\viewkind0
+{\colortbl;\red255\green255\blue255;\red0\green0\blue0;\red9\green79\blue209;}
+{\*\expandedcolortbl;;\cssrgb\c0\c0\c0\c84706\cname labelColor;\cssrgb\c0\c40784\c85490\cname linkColor;}
+\margl1440\margr1440\vieww9000\viewh8400\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 
-\f0\fs24 \cf0 FontGoggles Home:\
-{\field{\*\fldinst{HYPERLINK "https://github.com/justvanrossum/fontgoggles"}}{\fldrslt https://github.com/justvanrossum/fontgoggles}}\
+\f0\fs24 \cf2 FontGoggles Home:\cf0 \
+{\field{\*\fldinst{HYPERLINK "https://github.com/justvanrossum/fontgoggles"}}{\fldrslt \cf3 https://github.com/justvanrossum/fontgoggles}}\
 \
-FontGoggles was funded by Google Fonts:\
+\cf2 FontGoggles was funded by Google Fonts:\cf0 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://fonts.google.com/"}}{\fldrslt \cf0 https://fonts.google.com}}\
-\
+{\field{\*\fldinst{HYPERLINK "https://fonts.google.com/"}}{\fldrslt \cf3 https://fonts.google.com}}\
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
+\cf2 \
 FontGoggles depends on these fine open source projects:\
-\
+\cf0 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
-{\field{\*\fldinst{HYPERLINK "https://www.python.org"}}{\fldrslt \cf0 https://www.python.org}}\
-{\field{\*\fldinst{HYPERLINK "https://bitbucket.org/ronaldoussoren/pyobjc/src/default/"}}{\fldrslt https://bitbucket.org/ronaldoussoren/pyobjc/src/default/}}\
-{\field{\*\fldinst{HYPERLINK "https://github.com/ronaldoussoren/py2app"}}{\fldrslt https://github.com/ronaldoussoren/py2app}}\
+{\field{\*\fldinst{HYPERLINK "https://www.python.org"}}{\fldrslt \cf3 https://www.python.org}}\cf3 \
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://bitbucket.org/ronaldoussoren/pyobjc/src/default/"}}{\fldrslt \cf3 https://bitbucket.org/ronaldoussoren/pyobjc/src/default/}}\
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
+{\field{\*\fldinst{HYPERLINK "https://github.com/ronaldoussoren/py2app"}}{\fldrslt \cf3 https://github.com/ronaldoussoren/py2app}}\
 {\field{\*\fldinst{HYPERLINK "https://github.com/robotools/vanilla"}}{\fldrslt https://github.com/robotools/vanilla}}\
 {\field{\*\fldinst{HYPERLINK "https://github.com/fonttools/fonttools"}}{\fldrslt https://github.com/fonttools/fonttools}}\
 {\field{\*\fldinst{HYPERLINK "https://github.com/googlefonts/ufo2ft"}}{\fldrslt https://github.com/googlefonts/ufo2ft}}\
@@ -30,5 +33,6 @@ FontGoggles depends on these fine open source projects:\
 {\field{\*\fldinst{HYPERLINK "https://github.com/alberthier/corefoundationasyncio"}}{\fldrslt https://github.com/alberthier/corefoundationasyncio}}\
 {\field{\*\fldinst{HYPERLINK "https://docs.pytest.org/en/latest/"}}{\fldrslt https://docs.pytest.org/en/latest/}}\
 {\field{\*\fldinst{HYPERLINK "https://github.com/pytest-dev/pytest-asyncio"}}{\fldrslt https://github.com/pytest-dev/pytest-asyncio}}\
-{\field{\*\fldinst{HYPERLINK "https://github.com/justvanrossum/jundo"}}{\fldrslt https://github.com/justvanrossum/jundo}}\
-...and their respective dependencies.}
+{\field{\*\fldinst{HYPERLINK "https://github.com/justvanrossum/jundo"}}{\fldrslt https://github.com/justvanrossum/jundo}}\cf0 \
+\pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
+\cf2 ...and their respective dependencies.}


### PR DESCRIPTION
The About dialog `Credits.rtf` file needed a [developer color update](https://stackoverflow.com/a/53679540/2848172) to support automatic color transitions between Dark and Light mode. 

### Before

![fontgoggles_pre](https://user-images.githubusercontent.com/4249591/75742295-37ae8980-5cdb-11ea-9271-57965e4317bf.gif)

### After


![fontgoggles-post](https://user-images.githubusercontent.com/4249591/75742311-4006c480-5cdb-11ea-8066-931feab1a915.gif)
