### PR TITLE
Set buffer cluster level to MONOTONE_CHARACTERS

### DIFF
--- a/Lib/fontgoggles/misc/hbShape.py
+++ b/Lib/fontgoggles/misc/hbShape.py
@@ -172,6 +172,8 @@ class HBShape:
         buf.add_str(str(text))  # add_str() does not accept str subclasses
         buf.guess_segment_properties()
 
+        buf.cluster_level = hb.BufferClusterLevel.MONOTONE_CHARACTERS
+
         if direction is not None:
             buf.direction = direction
         if language is not None:


### PR DESCRIPTION
The default (`MONOTONE_GRAPHEMES`) will give combining marks the same cluster values as their bases (and combines also other grapheme clusters, though not the complete Unicode grapheme cluster spec).

A side effect of the default is that selecting a glyph for a combining mark will highlight the mark and the base in the Characters List, but with the new cluster level they will be highlighted separately so one can tell what the exact character corresponding to the selected glyphs.

There is also the more extreme `CHARACTERS` level but this one has no guarantee of monotonicity and I’m not sure the code is prepared for that (the other two level will ensure that clusters always monotonically increase in the buffer direction even if re-ordering is involved).