### PR TITLE
Add Homebrew installation documentation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 application for macOS. It is free and <a href="https://github.com/justvanrossum/fontgoggles">open source</a>.</p>
 <p>The main focus is text behavior, specifically text shaping and variation behavior.</p>
 <p>You can download <a href="https://github.com/justvanrossum/fontgoggles/releases/latest">the latest release here</a>.</p>
-<p>Homebrew users can install the <code>fontgoggles</code> cask with the command <code>brew install --cask fontgoggles</code></p>
+<p>Homebrew users can install the <code>fontgoggles</code> cask with the command <code>brew install --cask fontgoggles</code>.</p>
 <p>The following font formats are supported:</p>
 <ul>
 <li>.ttf/.otf (including variable fonts and COLR/CPAL-based color fonts)</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,7 @@
 application for macOS. It is free and <a href="https://github.com/justvanrossum/fontgoggles">open source</a>.</p>
 <p>The main focus is text behavior, specifically text shaping and variation behavior.</p>
 <p>You can download <a href="https://github.com/justvanrossum/fontgoggles/releases/latest">the latest release here</a>.</p>
+<p>Homebrew users can install the <code>fontgoggles</code> cask with the command <code>brew install --cask fontgoggles</code></p>
 <p>The following font formats are supported:</p>
 <ul>
 <li>.ttf/.otf (including variable fonts and COLR/CPAL-based color fonts)</li>

--- a/docsSource/index.md
+++ b/docsSource/index.md
@@ -13,6 +13,8 @@ The main focus is text behavior, specifically text shaping and variation behavio
 
 You can download [the latest release here](https://github.com/justvanrossum/fontgoggles/releases/latest).
 
+Homebrew users can install the `fontgoggles` cask with the command `brew install --cask fontgoggles`.
+
 The following font formats are supported:
 
 - .ttf/.otf (including variable fonts and COLR/CPAL-based color fonts)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,2 +1,5 @@
 markdown==3.3.4
 pillow==8.1.2
+fontTools==4.21.1
+fs==2.4.12
+brotli==1.0.9


### PR DESCRIPTION
I began to prep a Homebrew cask for Font Goggles and ran into a file conflict because it is already there! :) 

This PR adds the Homebrew install approach to the docs. 

A benefit of homebrew is that users will get auto-updates of the Font Goggles application cask when they run the standard `brew update && brew upgrade` command to update other homebrew managed packages (assumes that someone maintains the [package file](https://github.com/Homebrew/homebrew-cask/blob/master/Casks/fontgoggles.rb) with updates here...)