### PR TITLE
Fix AttributeError in mark feature writer

### DIFF
--- a/Lib/fontgoggles/compile/ufoCompiler.py
+++ b/Lib/fontgoggles/compile/ufoCompiler.py
@@ -186,6 +186,8 @@ class MinimalFontObject:
         self.groups = reader.readGroups()
         self.kerning = reader.readKerning()
         self.lib = reader.readLib()
+        self.info = SimpleNamespace()
+        reader.readInfo(self.info)
         self._glyphs = {}
 
     def keys(self):

--- a/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/asteriskabovecmb.glif
+++ b/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/asteriskabovecmb.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="asteriskabovecmb" format="2">
+  <advance width="310"/>
+  <unicode hex="20F0"/>
+  <anchor x="153" y="808" name="_top"/>
+  <outline>
+    <contour>
+      <point x="60" y="840" type="line"/>
+      <point x="250" y="840" type="line"/>
+      <point x="250" y="965" type="line"/>
+      <point x="60" y="965" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/asteriskbelowcmb.glif
+++ b/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/asteriskbelowcmb.glif
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="asteriskbelowcmb" format="2">
+  <advance width="310"/>
+  <unicode hex="0359"/>
+  <anchor x="153" y="808" name="_top"/>
+  <outline>
+    <contour>
+      <point x="60" y="840" type="line"/>
+      <point x="250" y="840" type="line"/>
+      <point x="250" y="965" type="line"/>
+      <point x="60" y="965" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/contents.plist
+++ b/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/glyphs/contents.plist
@@ -76,6 +76,10 @@
     <string>arrowright.glif</string>
     <key>arrowup</key>
     <string>arrowup.glif</string>
+    <key>asteriskabovecmb</key>
+    <string>asteriskabovecmb.glif</string>
+    <key>asteriskbelowcmb</key>
+    <string>asteriskbelowcmb.glif</string>
     <key>colon</key>
     <string>colon.glif</string>
     <key>comma</key>

--- a/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/lib.plist
+++ b/Tests/data/MutatorSans/MutatorSansBoldWideMutated.ufo/lib.plist
@@ -100,6 +100,8 @@
     <string>curve</string>
     <key>com.typemytype.robofont.shouldAddPointsInSplineConversion</key>
     <integer>1</integer>
+    <key>com.typemytype.robofont.smartSets.uniqueKey</key>
+    <string>4751298192</string>
     <key>com.typesupply.defcon.sortDescriptor</key>
     <array>
       <dict>
@@ -393,6 +395,8 @@
       <string>arrowup</string>
       <string>em</string>
       <string>macroncmb</string>
+      <string>asteriskbelowcmb</string>
+      <string>asteriskabovecmb</string>
     </array>
   </dict>
 </plist>

--- a/Tests/test_ufoCompiler.py
+++ b/Tests/test_ufoCompiler.py
@@ -16,7 +16,11 @@ def test_ufoCharacterMapping():
     # MutatorSansBoldWideMutated.ufo/glyphs/A_.glif contains a commented-out <unicode>
     # tag, that must not be parsed, as well as a commented-out <anchor>.
     assert 0x1234 not in cmap
-    assert anchors == {"A": [("top", 645, 815)], "E": [("top", 582.5, 815)], "macroncmb": [("_top", 0, 815)]}
+    assert anchors == {
+        "A": [("top", 645, 815)],
+        "E": [("top", 582.5, 815)],
+        "macroncmb": [("_top", 0, 815)],
+    }
 
 
 def test_ufoCharacterMapping_glyphNames():

--- a/Tests/test_ufoCompiler.py
+++ b/Tests/test_ufoCompiler.py
@@ -20,6 +20,8 @@ def test_ufoCharacterMapping():
         "A": [("top", 645, 815)],
         "E": [("top", 582.5, 815)],
         "macroncmb": [("_top", 0, 815)],
+        "asteriskabovecmb": [("_top", 153, 808)],
+        "asteriskbelowcmb": [("_top", 153, 808)],
     }
 
 


### PR DESCRIPTION
Turns out `MinimalFont` was too minimal in not even supporting `font.info`.