### PR TITLE
Refactor UI colors vs. CPAL colors

### DIFF
--- a/Lib/fontgoggles/font/glyphDrawing.py
+++ b/Lib/fontgoggles/font/glyphDrawing.py
@@ -1,6 +1,6 @@
-from AppKit import NSGraphicsContext, NSColorSpace
+from AppKit import NSGraphicsContext
 from fontTools.misc.arrayTools import unionRect
-from ..mac.drawing import rectFromNSRect
+from ..mac.drawing import rectFromNSRect, nsColorFromRGBA
 from ..misc.properties import cachedProperty
 
 
@@ -28,7 +28,7 @@ class GlyphDrawing:
         return bounds
 
     def draw(self, colorPalette, defaultColor):
-        defaultColor.set()
+        nsColorFromRGBA(defaultColor).set()
         self.path.fill()
 
     def pointInside(self, pt):
@@ -60,7 +60,7 @@ class GlyphLayersDrawing:
                 if colorID < len(colorPalette) else
                 defaultColor
             )
-            color.set()
+            nsColorFromRGBA(color).set()
             path.fill()
 
     def pointInside(self, pt):
@@ -79,18 +79,12 @@ class GlyphCOLRv1Drawing:
     def draw(self, colorPalette, defaultColor):
         from blackrenderer.backends.coregraphics import CoreGraphicsCanvas
 
-        palette = [
-            colorPalette[index].getRed_green_blue_alpha_(None, None, None, None)
-            for index in range(len(colorPalette))
-        ]
-        textColor = defaultColor.colorUsingColorSpace_(NSColorSpace.genericRGBColorSpace()).getRed_green_blue_alpha_(None, None, None, None)
-
         cgContext = NSGraphicsContext.currentContext().CGContext()
         self.colorFont.drawGlyph(
             self.glyphName,
             CoreGraphicsCanvas(cgContext),
-            palette=palette,
-            textColor=textColor,
+            palette=colorPalette,
+            textColor=defaultColor,
         )
 
     def pointInside(self, pt):

--- a/Lib/fontgoggles/mac/drawing.py
+++ b/Lib/fontgoggles/mac/drawing.py
@@ -38,13 +38,17 @@ def rectFromNSRect(nsRect):
     return x, y, x + w, y + h
 
 
-def rgbColor(r, g, b, a=1.0):
-    return AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(r, g, b, a)
+def nsColorFromRGBA(rgba):
+    return AppKit.NSColor.colorWithCalibratedRed_green_blue_alpha_(*rgba)
 
 
-def rgbFromNSColor(color):
+def rgbaFromNSColor(color):
     color = color.colorUsingColorSpace_(AppKit.NSColorSpace.genericRGBColorSpace())
     return color.getRed_green_blue_alpha_(None, None, None, None)
+
+
+def blendRGBA(factor, rgba1, rgba2):
+    return tuple([ch1 + factor * (ch2 - ch1) for ch1, ch2 in zip(rgba1, rgba2)])
 
 
 def grayColor(gray, a=1.0):

--- a/Tests/test_colorFont.py
+++ b/Tests/test_colorFont.py
@@ -23,10 +23,9 @@ async def test_colrV1Font():
     h -= y
     surface = CoreGraphicsPixelSurface(x, y, w, h)
     context = NSGraphicsContext.graphicsContextWithCGContext_flipped_(surface.context, False)
-    palette = glyphDrawing.colorFont.palettes[0]
     savedContext = NSGraphicsContext.currentContext()
     try:
         NSGraphicsContext.setCurrentContext_(context)
-        glyphDrawing.draw(palette, NSColor.blackColor())
+        glyphDrawing.draw(glyphs.colorPalette, NSColor.blackColor())
     finally:
         NSGraphicsContext.setCurrentContext_(savedContext)

--- a/Tests/test_colorFont.py
+++ b/Tests/test_colorFont.py
@@ -1,5 +1,5 @@
 import pytest
-from AppKit import NSGraphicsContext, NSColor
+from AppKit import NSGraphicsContext
 from blackrenderer.backends.coregraphics import CoreGraphicsPixelSurface
 from fontgoggles.font import getOpener
 from fontgoggles.misc.textInfo import TextInfo
@@ -26,6 +26,6 @@ async def test_colrV1Font():
     savedContext = NSGraphicsContext.currentContext()
     try:
         NSGraphicsContext.setCurrentContext_(context)
-        glyphDrawing.draw(glyphs.colorPalette, NSColor.blackColor())
+        glyphDrawing.draw(glyphs.colorPalette, (0, 0, 0, 1))
     finally:
         NSGraphicsContext.setCurrentContext_(savedContext)

--- a/Tests/test_colorFont.py
+++ b/Tests/test_colorFont.py
@@ -23,10 +23,7 @@ async def test_colrV1Font():
     h -= y
     surface = CoreGraphicsPixelSurface(x, y, w, h)
     context = NSGraphicsContext.graphicsContextWithCGContext_flipped_(surface.context, False)
-    palette = [
-        NSColor.colorWithCalibratedRed_green_blue_alpha_(*c)
-        for c in glyphDrawing.colorFont.palettes[0]
-    ]
+    palette = glyphDrawing.colorFont.palettes[0]
     savedContext = NSGraphicsContext.currentContext()
     try:
         NSGraphicsContext.setCurrentContext_(context)


### PR DESCRIPTION
Generally keep colors as rgba tuples, and only convert to NSColor late. This avoids a bunch of unneeded conversion, and should perform a bit better for large palettes.