### PR TITLE
Add ARM architecture to dylib

### DIFF
--- a/Turbo/build_lib.sh
+++ b/Turbo/build_lib.sh
@@ -9,4 +9,4 @@ mkdir -p build
 
 cc -g -fPIC -c -mmacosx-version-min=10.9 -o build/makePathFromOutline.o makePathFromOutline.m
 
-cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -lsystem.b build/makePathFromOutline.o
+cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64 -lsystem.b build/makePathFromOutline.o


### PR DESCRIPTION
I tried to build FontGoggles on an M1 Mac. All I had to change in the code was to add the ARM architecture to the build script for the dylib.

Some other caveats:
- I had an old local installation of `freetype` which I had to recompile for ARM. No idea how I would build a universal version.
- `lxml` when installed via pip always had the wrong architecture, clearing it from the pip cache helped.