### PR TITLE
Add arm64e architecture to building path generation library

### DIFF
--- a/Turbo/build_lib.sh
+++ b/Turbo/build_lib.sh
@@ -7,6 +7,6 @@ cd "${0%/*}"  # cd into the folder containing this script
 
 mkdir -p build
 
-cc -g -fPIC -c -mmacosx-version-min=10.9 -o build/makePathFromOutline.o makePathFromOutline.m
+cc -g -fPIC -c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64e -o build/makePathFromOutline.o makePathFromOutline.m
 
-cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -lsystem.b build/makePathFromOutline.o
+cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64e -lsystem.b build/makePathFromOutline.o


### PR DESCRIPTION
Fixes running FontGoggles development app on Apple silicon.