### PR TITLE
Added arm64 architecture to support m1

### DIFF
--- a/Turbo/build_lib.sh
+++ b/Turbo/build_lib.sh
@@ -7,6 +7,6 @@ cd "${0%/*}"  # cd into the folder containing this script
 
 mkdir -p build
 
-cc -g -fPIC -c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64e -arch arm64 -o build/makePathFromOutline.o makePathFromOutline.m
+cc -g -fPIC -c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64 -o build/makePathFromOutline.o makePathFromOutline.m
 
-cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64e -arch arm64 -lsystem.b build/makePathFromOutline.o
+cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64 -lsystem.b build/makePathFromOutline.o

--- a/Turbo/build_lib.sh
+++ b/Turbo/build_lib.sh
@@ -7,6 +7,6 @@ cd "${0%/*}"  # cd into the folder containing this script
 
 mkdir -p build
 
-cc -g -fPIC -c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64e -o build/makePathFromOutline.o makePathFromOutline.m
+cc -g -fPIC -c -mmacosx-version-min=10.9 -arch x86_64 -arch arm64e -arch arm64 -o build/makePathFromOutline.o makePathFromOutline.m
 
-cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64e -lsystem.b build/makePathFromOutline.o
+cc -dynamiclib -mmacosx-version-min=10.9 -o ../Lib/fontgoggles/mac/libmakePathFromOutline.dylib -framework AppKit -arch x86_64 -arch arm64e -arch arm64 -lsystem.b build/makePathFromOutline.o


### PR DESCRIPTION
Fixes an issue noticed in #25 when trying to compile and run locally on a M1 Mac. I'm not sure how this is considered for actual builds, since I so far had no issues with the installable releases.

The original error when running without `arm64` explicitly added to the Turbo build:

```
ERROR:root:insertFonts
Traceback (most recent call last):
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/misc/decorators.py", line 59, in wrapper
    return func(*args, **kwargs)
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/fontList.py", line 521, in insertFonts
    items = sortedFontPathsAndNumbers(pathsExternal, defaultSortSpec) + pathsAndFontNumbers
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/font/__init__.py", line 29, in sortedFontPathsAndNumbers
    expandedPaths = list(iterFontPathsAndNumbers(paths))
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/font/__init__.py", line 46, in iterFontPathsAndNumbers
    yield from iterFontNumbers(path)
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/font/__init__.py", line 52, in iterFontNumbers
    numFonts, opener, getSortInfo = getOpener(path)
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/font/__init__.py", line 11, in getOpener
    module = importlib.import_module(moduleName)
  File "/Users/johannes/.pyenv/versions/3.10.4/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/font/otfFont.py", line 6, in <module>
    from ..mac.makePathFromOutline import makePathFromGlyph
  File "/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/makePathFromOutline.py", line 26, in <module>
    _lib = ctypes.cdll.LoadLibrary(_libPath)
  File "/Users/johannes/.pyenv/versions/3.10.4/lib/python3.10/ctypes/__init__.py", line 452, in LoadLibrary
    return self._dlltype(name)
  File "/Users/johannes/.pyenv/versions/3.10.4/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: dlopen(/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/libmakePathFromOutline.dylib, 0x0006): tried: '/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/libmakePathFromOutline.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64e', need 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/libmakePathFromOutline.dylib' (no such file), '/Users/johannes/Projects/fontgoggles/Lib/fontgoggles/mac/libmakePathFromOutline.dylib' (fat file, but missing compatible architecture (have 'x86_64,arm64e', need 'arm64'))
```