### PR TITLE
Implementing VF instance selector

### DIFF
--- a/Lib/fontgoggles/mac/mainWindow.py
+++ b/Lib/fontgoggles/mac/mainWindow.py
@@ -303,9 +303,10 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
                                                        showHiddenAxes=self.project.uiSettings.showHiddenAxes)
 
         self.variationsGroup.instances = LabeledView(
-            (0, 0, 0, 1),  # gets updated as axes are read
+            # Position and instances gets updated as fonts are read
+            (0, 0, 0, 20),
             "Instances:",
-            PopUpButton, ["Instance One", "Instance Two"],
+            PopUpButton, [],
             callback=self.varInstanceChanged,
         )
 
@@ -548,6 +549,7 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
         allFeatureTagsGSUB = set()
         allFeatureTagsGPOS = set()
         allAxes = []
+        allInstances = [("No instance selected", {})]
         allScriptsAndLanguages = []
         allStylisticSetNames = []
         for fontItemInfo in fonts:
@@ -559,13 +561,15 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
             allAxes.append(font.axes)
             allScriptsAndLanguages.append(font.scripts)
             allStylisticSetNames.append(font.stylisticSetNames)
+            allInstances.extend(font.instances)
         allAxes = mergeAxes(*allAxes)
         allScriptsAndLanguages = mergeScriptsAndLanguages(*allScriptsAndLanguages)
         allStylisticSetNames = mergeStylisticSetNames(*allStylisticSetNames)
-        return allFeatureTagsGSUB, allFeatureTagsGPOS, allAxes, allScriptsAndLanguages, allStylisticSetNames
+        return allFeatureTagsGSUB, allFeatureTagsGPOS, allAxes, allInstances, \
+            allScriptsAndLanguages, allStylisticSetNames
 
     @objc.python_method
-    def _updateSidebarItems(self, allFeatureTagsGSUB, allFeatureTagsGPOS, allAxes,
+    def _updateSidebarItems(self, allFeatureTagsGSUB, allFeatureTagsGPOS, allAxes, allInstances,
                             allScriptsAndLanguages, allStylisticSetNames):
         self.featuresGroup.setTags({"GSUB": allFeatureTagsGSUB, "GPOS": allFeatureTagsGPOS},
                                    allStylisticSetNames)
@@ -594,8 +598,11 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
             isAxisRegistered = tag == tag.lower()  # all lowercase tags are registered axes
             return not isAxisRegistered, axisInfo.label.lower()
         sliderInfo = {k: v for k, v in sorted(sliderInfo.items(), key=sorter)}
+
         self.variationsGroup.axisSliders.setSliderInfo(sliderInfo)
         self.variationsGroup.instances.setPosSize((0, self.variationsGroup.axisSliders.getPosSize()[3], 0, 40)),
+        self.variationsGroup.instances.setItems([i[0] for i in allInstances])
+
         scriptTags = sorted(allScriptsAndLanguages)
         scriptMenuTitles = ['Automatic'] + [f"{tag} – {opentypeTags.scripts.get(tag, '?')}" for tag in scriptTags]
         selectedItem = self.scriptsPopup.getItem()
@@ -975,13 +982,21 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
 
     @objc.python_method
     def varLocationChanged(self, sender):
+        """Axis slider value changed"""
+        _, _, _, allInstances, _, _ = self._gatherSidebarInfo(self.project.fonts)
         self.project.textSettings.varLocation = {k: v for k, v in sender.get().items() if v is not None}
         self.textEntryChangedCallback(self.textEntry, updateCharacterList=False)
+        self.variationsGroup.instances.setItems([i[0] for i in allInstances])
+        # Reset instance popup
+        self.variationsGroup.instances.set(0)
 
     @objc.python_method
     def varInstanceChanged(self, sender):
-        self.project.textSettings.varLocation = {k: v for k, v in sender.get().items() if v is not None}
+        """Instance was selected from popup"""
+        _, _, _, allInstances, _, _ = self._gatherSidebarInfo(self.project.fonts)
+        self.project.textSettings.varLocation = {k: v for k, v in allInstances[sender.get()][1].items() if v is not None}
         self.textEntryChangedCallback(self.textEntry, updateCharacterList=False)
+        self.variationsGroup.axisSliders.set(self.project.textSettings.varLocation)
 
     @objc.python_method
     def relativeSizeChangedCallback(self, sender):

--- a/Lib/fontgoggles/mac/mainWindow.py
+++ b/Lib/fontgoggles/mac/mainWindow.py
@@ -161,7 +161,7 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
         uiSettings.compileOutputSize = self.fontListSplitView.paneSize("compileOutput")
         uiSettings.formattingOptionsVisible = self.w.mainSplitView.isPaneReallyVisible("formattingOptions")
         uiSettings.feaVarTabSelection = feaVarTabValues[self.feaVarTabs.get()]
-        uiSettings.showHiddenAxes = self.variationsGroup.showHiddenAxes
+        uiSettings.showHiddenAxes = self.variationsGroup.axisSliders.showHiddenAxes
 
     @objc.python_method
     def restoreWindowPosition(self, windowPosition):
@@ -287,19 +287,34 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
         group.feaVarTabs = self.feaVarTabs
         group.feaVarTabs.set(feaVarTabValues.index(self.project.uiSettings.feaVarTabSelection))
 
+        # Sidebar first tab
         featuresTab = group.feaVarTabs[0]
         self.featuresGroup = FeatureTagGroup(sidebarWidth - 6, {}, callback=self.featuresChanged)
         featuresTab.main = AligningScrollView((0, 0, 0, 0), self.featuresGroup, drawBackground=False,
                                               hasHorizontalScroller=False, autohidesScrollers=True,
                                               borderType=AppKit.NSNoBorder)
 
+        # Sidebar second tab
         variationsTab = group.feaVarTabs[1]
-        self.variationsGroup = SliderGroup(sidebarWidth - 6, {}, callback=self.varLocationChanged,
-                                           showHiddenAxes=self.project.uiSettings.showHiddenAxes)
+        self.variationsGroup = Group((0, 0, 0, 0))
+
+        self.variationsGroup.axisSliders = SliderGroup(sidebarWidth - 6, {},
+                                                       callback=self.varLocationChanged,
+                                                       showHiddenAxes=self.project.uiSettings.showHiddenAxes)
+
+        self.variationsGroup.instances = LabeledView(
+            (0, 0, 0, 1),  # gets updated as axes are read
+            "Instances:",
+            PopUpButton, ["Instance One", "Instance Two"],
+            callback=self.varInstanceChanged,
+        )
+
+        # The content of the tab wrapping the axes sliders and instance dropdown
         variationsTab.main = AligningScrollView((0, 0, 0, 0), self.variationsGroup, drawBackground=False,
                                                 hasHorizontalScroller=False, autohidesScrollers=True,
                                                 borderType=AppKit.NSNoBorder)
 
+        # Sidebar third tab
         optionsTab = group.feaVarTabs[2]
         relativeFontSize = self.project.textSettings.relativeFontSize * 100
         relativeBaseline = self.getRelativeBaselineValueForSlider()
@@ -579,7 +594,8 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
             isAxisRegistered = tag == tag.lower()  # all lowercase tags are registered axes
             return not isAxisRegistered, axisInfo.label.lower()
         sliderInfo = {k: v for k, v in sorted(sliderInfo.items(), key=sorter)}
-        self.variationsGroup.setSliderInfo(sliderInfo)
+        self.variationsGroup.axisSliders.setSliderInfo(sliderInfo)
+        self.variationsGroup.instances.setPosSize((0, self.variationsGroup.axisSliders.getPosSize()[3], 0, 40)),
         scriptTags = sorted(allScriptsAndLanguages)
         scriptMenuTitles = ['Automatic'] + [f"{tag} – {opentypeTags.scripts.get(tag, '?')}" for tag in scriptTags]
         selectedItem = self.scriptsPopup.getItem()
@@ -598,7 +614,7 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
         languageTags = [_tagFromMenuItem(item, "dflt") for item in self.languagesPopup.getItems()]
         self.languagesPopup.set(languageTags.index(self.project.textSettings.language))
         self.featuresGroup.set(self.project.textSettings.features)
-        self.variationsGroup.set(self.project.textSettings.varLocation)
+        self.variationsGroup.axisSliders.set(self.project.textSettings.varLocation)
 
     def iterFontItems(self):
         return self.fontList.iterFontItems()
@@ -959,6 +975,11 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
 
     @objc.python_method
     def varLocationChanged(self, sender):
+        self.project.textSettings.varLocation = {k: v for k, v in sender.get().items() if v is not None}
+        self.textEntryChangedCallback(self.textEntry, updateCharacterList=False)
+
+    @objc.python_method
+    def varInstanceChanged(self, sender):
         self.project.textSettings.varLocation = {k: v for k, v in sender.get().items() if v is not None}
         self.textEntryChangedCallback(self.textEntry, updateCharacterList=False)
 


### PR DESCRIPTION
Here's a start for #25 — I'm pretty sure there is things I missed with the overall flow of the app and with vanilla in particular, so happy to take your pointers.

I've added the instance parsing to otfFont.py for now — I'm not using the designspace workflow myself, but I assume it should expose them as well? I'm adding the family to the instance name, otherwise it becomes confusing with several files. I've opted for a default "No instance selected" and using the sliders also resets to this. 

One visual thing I couldn't figure out is how to give the PopUp the same margin as the slider container; I tried with those same "margin" settings and negative widths, but that just created havoc. Now the instance Popup goes from edge to edge, when it would be nicer to have that little margin. The PopUp is placed under the axes and I'm updating the y position inside the tab based off the axis widget's calculated height — not sure if there is a more automatic way to stack (and update) items inside a Vanilla Group.