### PR TITLE
Upgrade to Python 3.9 (for now)

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -25,9 +25,9 @@ jobs:
         rm -fr *.p12
         # security find-identity -v -p codesigning
 
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       run: |
-        curl https://www.python.org/ftp/python/3.7.6/python-3.7.6-macosx10.9.pkg --output pythonInstaller.pkg
+        curl https://www.python.org/ftp/python/3.9.13/python-3.9.13-macosx10.9.pkg --output pythonInstaller.pkg
         sudo installer -pkg pythonInstaller.pkg -target /
 
     - name: Check Python
@@ -51,8 +51,8 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-dev.txt
         pip install .
-        # Install custom wheels to workaround various problems, see App/CustomWheels/README.md
-        pip install --upgrade App/CustomWheels/lxml-4.5.0-cp37-cp37m-macosx_10_9_x86_64.whl
+        ## Install custom wheels to workaround various problems, see App/CustomWheels/README.md
+        # pip install --upgrade App/CustomWheels/lxml-4.5.0-cp37-cp37m-macosx_10_9_x86_64.whl
 
     - name: Run Tests
       run: |

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ uharfbuzz==0.32.0
 python-bidi==0.4.2
 jundo==0.1.2
 ufo2ft==2.29.0
-numpy==1.24.0
+numpy==1.21.4  # pyup: ignore
 unicodedata2==15.0.0
 git+https://github.com/BlackFoundryCom/rcjk-tools/

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ uharfbuzz==0.32.0
 python-bidi==0.4.2
 jundo==0.1.2
 ufo2ft==2.29.0
-numpy==1.21.4  # pyup: ignore
+numpy==1.24.0
 unicodedata2==15.0.0
 git+https://github.com/BlackFoundryCom/rcjk-tools/


### PR DESCRIPTION
This (somewhat) fixes #222.

Upgrading to 3.10/3.11 is a huge rabbit hole due to M1/Intel/universal2 woes, but let's at least try to move to 3.9.