### PR TITLE
Fold Hira and Kana into one, keep them in the same segment

### DIFF
--- a/Lib/fontgoggles/misc/segmenting.py
+++ b/Lib/fontgoggles/misc/segmenting.py
@@ -15,6 +15,7 @@ from bidi.algorithm import (  # noqa: ignore E402
     reorder_resolved_levels, PARAGRAPH_LEVELS,
 )
 from bidi.mirror import MIRRORED  # noqa: ignore E402
+from fontTools.unicodedata.OTTags import SCRIPT_EXCEPTIONS
 
 
 UNKNOWN_SCRIPT = {"Zinh", "Zyyy", "Zxxx"}
@@ -38,7 +39,10 @@ def textSegments(txt):
     chars = list(zip(txt, scripts, levels))
 
     runLenghts = []
-    for value, sub in itertools.groupby(chars, key=lambda item: item[1:]):
+    for value, sub in itertools.groupby(
+        chars,
+        key=lambda item: (SCRIPT_EXCEPTIONS.get(item[1], item[1].lower()), item[2]),
+    ):
         runLenghts.append(len(list(sub)))
 
     segments = []

--- a/Tests/test_segmenting.py
+++ b/Tests/test_segmenting.py
@@ -141,6 +141,8 @@ testDataTextSegments = [
     ("\u0627123\u0627", 1, [("\u0627", "Arab", 1, 0), ("123", "Arab", 2, 1), ("\u0627", "Arab", 1, 4)]),
     ("123\u0627", 1, [("123", "Arab", 2, 0), ("\u0627", "Arab", 1, 3)]),
     ("a123\u0627", 0, [("a123", "Latn", 0, 0), ("\u0627", "Arab", 1, 4)]),
+    ("すペ", 0, [("すペ", "Hira", 0, 0)]),  # Kana is folded to Hira, see issue #310
+    ("ペす", 0, [("ペす", "Kana", 0, 0)]),  # Hira is folded to Kana, see issue #310
 ]
 
 


### PR DESCRIPTION
When segmenting the text, fold the script code to the one used by OpenType, which (among other things) causes Hiragana and Katakana to be seen as the same script, and therefore will end in the same segment.

This fixes #310.