### PR TITLE
Fall back to 'L' direction for chars not defined in unicode

### DIFF
--- a/Lib/fontgoggles/misc/segmenting.py
+++ b/Lib/fontgoggles/misc/segmenting.py
@@ -129,6 +129,7 @@ def getBiDiInfo(text, *, upper_is_rtl=False, base_dir=None, debug=False):
     storage['base_dir'] = ('L', 'R')[base_level]
 
     get_embedding_levels(text, storage, upper_is_rtl, debug)
+    fix_bidi_type_for_unknown_chars(storage)
     assert len(text) == len(storage["chars"])
     for index, (ch, chInfo) in enumerate(zip(text, storage["chars"])):
         assert ch == chInfo["ch"]
@@ -141,3 +142,9 @@ def getBiDiInfo(text, *, upper_is_rtl=False, base_dir=None, debug=False):
     reorder_resolved_levels(storage, debug)
 
     return storage
+
+
+def fix_bidi_type_for_unknown_chars(storage):
+    for _ch in storage['chars']:
+        if _ch['type'] == '':
+            _ch['type'] = 'L'

--- a/Lib/fontgoggles/misc/segmenting.py
+++ b/Lib/fontgoggles/misc/segmenting.py
@@ -145,6 +145,9 @@ def getBiDiInfo(text, *, upper_is_rtl=False, base_dir=None, debug=False):
 
 
 def fix_bidi_type_for_unknown_chars(storage):
+    """Set any bidi type of '' (symptom of a character not known by unicode)
+    to 'L', to prevent the other bidi code to fail (issue 313).
+    """
     for _ch in storage['chars']:
         if _ch['type'] == '':
             _ch['type'] = 'L'

--- a/Tests/test_segmenting.py
+++ b/Tests/test_segmenting.py
@@ -134,6 +134,7 @@ def test_detectScript(testString, expectedScripts):
 
 testDataTextSegments = [
     ("a", 0, [("a", "Latn", 0, 0)]),
+    ("\u1FF0", 0, [("\u1FF0", "Zzzz", 0, 0)]),  # test char should *not* be defined in Unicode: issue #313
     ("\u0627", 1, [("\u0627", "Arab", 1, 0)]),
     ("a\u0627", 0, [("a", "Latn", 0, 0), ("\u0627", "Arab", 1, 1)]),
     ("\u0627123", 1, [("\u0627", "Arab", 1, 0), ("123", "Arab", 2, 1)]),


### PR DESCRIPTION
This fixes #313.