### PR TITLE
Make combining marks inherit script

### DIFF
--- a/Lib/fontgoggles/misc/segmenting.py
+++ b/Lib/fontgoggles/misc/segmenting.py
@@ -73,6 +73,7 @@ def detectScript(txt):
     for i, ch in enumerate(txt):
         scr = charScript[i]
         cat = category(ch)
+        # Non-spacing mark (Mn) should always inherit script
         if scr in UNKNOWN_SCRIPT or cat == "Mn":
             if i:
                 scr = charScript[i-1]

--- a/Lib/fontgoggles/misc/segmenting.py
+++ b/Lib/fontgoggles/misc/segmenting.py
@@ -72,12 +72,12 @@ def detectScript(txt):
 
     for i, ch in enumerate(txt):
         scr = charScript[i]
-        if scr in UNKNOWN_SCRIPT:
+        cat = category(ch)
+        if scr in UNKNOWN_SCRIPT or cat == "Mn":
             if i:
                 scr = charScript[i-1]
             else:
                 scr = None
-            cat = category(ch)
             if ch in MIRRORED and cat == "Pe":
                 scr = None
         charScript[i] = scr

--- a/Tests/test_segmenting.py
+++ b/Tests/test_segmenting.py
@@ -106,6 +106,24 @@ testData = [
                       'sor': 'R',
                       'start': 0,
                       'type': 'AL'}])}),
+    (
+        "\u0639\u05b7\u0631\u05b7\u0628\u05b4",
+        {
+            "base_dir": "R",
+            "base_level": 1,
+            "chars": [
+                {"ch": "ִ", "index": 5, "level": 1, "orig": "NSM", "type": "R"},
+                {"ch": "ب", "index": 4, "level": 1, "orig": "AL", "type": "R"},
+                {"ch": "ַ", "index": 3, "level": 1, "orig": "NSM", "type": "R"},
+                {"ch": "ر", "index": 2, "level": 1, "orig": "AL", "type": "R"},
+                {"ch": "ַ", "index": 1, "level": 1, "orig": "NSM", "type": "R"},
+                {"ch": "ع", "index": 0, "level": 1, "orig": "AL", "type": "R"},
+            ],
+            "runs": deque(
+                [{"eor": "R", "length": 6, "sor": "R", "start": 0, "type": "NSM"}]
+            ),
+        },
+    ),
 ]
 
 


### PR DESCRIPTION
Some combining marks are assigned a specific script instead of Inherited script, but it is sometimes desirable to use them with another script (e.g. Hebrew Nikud used with Arabic letters in some historical texts). This change makes any Mn (Mark, Nonspacing) character work like it has Common or Inherited script.

Unicode script segmentation is under specified, and implementations differ. Firefox seems to do something similar to this change, other implementations don’t.