### PR TITLE
Fix universal

### DIFF
--- a/App/Distribute/ensure_universal_wheels.py
+++ b/App/Distribute/ensure_universal_wheels.py
@@ -127,6 +127,13 @@ def main():
             assert len(universal_wheels) == 1, universal_wheels
             download_file(universal_wheels[0], wheels_dir)
         elif platform_wheels:
+            if len(platform_wheels) > 2:
+                # There may be multiple wheels per platform. Pick the first of each from
+                # a sorted list.
+                platform_wheels = sorted(platform_wheels)
+                x86_64 = [pw for pw in platform_wheels if "x86_64" in pw.rsplit("/", 1)[-1]]
+                arm64 = [pw for pw in platform_wheels if "arm64" in pw.rsplit("/", 1)[-1]]
+                platform_wheels = [x86_64[0], arm64[1]]
             assert len(platform_wheels) == 2, platform_wheels
             merge_wheels(platform_wheels[0], platform_wheels[1], wheels_dir)
         else:

--- a/App/Distribute/ensure_universal_wheels.py
+++ b/App/Distribute/ensure_universal_wheels.py
@@ -124,10 +124,10 @@ def main():
                     platform_wheels.append(file_descriptor["url"])
 
         if universal_wheels:
-            assert len(universal_wheels) == 1
+            assert len(universal_wheels) == 1, universal_wheels
             download_file(universal_wheels[0], wheels_dir)
         elif platform_wheels:
-            assert len(platform_wheels) == 2
+            assert len(platform_wheels) == 2, platform_wheels
             merge_wheels(platform_wheels[0], platform_wheels[1], wheels_dir)
         else:
             raise IncompatibleWheelError(


### PR DESCRIPTION
numpy 2.0 broke the universal wheel merge logic, as it provides multiple wheels for each platform. This PR works around that.