### PR TITLE
Fix menu title validation: show/hide view toggles

### DIFF
--- a/Lib/fontgoggles/mac/mainWindow.py
+++ b/Lib/fontgoggles/mac/mainWindow.py
@@ -1051,7 +1051,6 @@ class FGMainWindowController(AppKit.NSWindowController, metaclass=ClassNameIncre
     def showMetrics_(self, sender):
         self.fontList.showMetrics = not self.fontList.showMetrics
 
-    @objc.python_method
     @suppressAndLogException
     def validateMenuItem_(self, sender):
         action = sender.action()


### PR DESCRIPTION
This fixes #513.

This `validateMenuItem_()` method must *not* be a python_method, because it must be callable as a delegate method.